### PR TITLE
Add support for 18i8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CFLAGS?=-g -Wall -Wno-unused-function
 RW?=robtk/
 
-APPTITLE=Scarlett 18i6 Mixer
+APPTITLE=Scarlett 18i6/18i8 Mixer
 APP_SRC=src/scarlett_mixer.c
 PUGL_SRC=$(RW)pugl/pugl_x11.c
 
@@ -15,7 +15,7 @@ GLUICFLAGS=-I. -I$(RW)
 GLUICFLAGS+=`pkg-config --cflags cairo pango lv2 glu alsa` -pthread
 GLUICFLAGS+=-DDEFAULT_NOT_ONTOP
 
-LOADLIBES=`pkg-config --libs $(PKG_UI_FLAGS) cairo pangocairo pango glu gl alsa` -lX11
+LOADLIBES=`pkg-config --libs $(PKG_UI_FLAGS) cairo pangocairo pango glu gl alsa` -lX11 -lm
 
 ###############################################################################
 all: scarlett-mixer
@@ -23,7 +23,7 @@ all: scarlett-mixer
 # TODO source $(RW)robtk.mk, add dependencies
 
 scarlett-mixer: $(APP_SRC) $(RW)robtkapp.c $(RW)ui_gl.c $(PUGL_SRC) Makefile
-	$(CXX) $(CPPFLAGS) \
+	$(CC) $(CPPFLAGS) \
 		-o $@ \
 		$(CFLAGS) $(GLUICFLAGS) \
 		-DXTERNAL_UI -DHAVE_IDLE_IFACE -DRTK_DESCRIPTOR=lv2ui_descriptor \

--- a/meson.build
+++ b/meson.build
@@ -15,9 +15,6 @@ deps = [
   cc.find_library('X11'),
 ]
 
-name = 'Scarlett ' + get_option('num_inputs') + 'i' + get_option('num_outputs')
-apptitle = '-DAPPTITLE="' + name + ' Mixer"'
-
 executable('scarlett-mixer',
   sources: [
     'robtk/robtkapp.c',
@@ -27,7 +24,7 @@ executable('scarlett-mixer',
   dependencies: deps,
   include_directories: include_directories('robtk'),
   c_args: [
-    apptitle,
+    '-DAPPTITLE="Scarlett 18i6/18i8 Mixer"',
     '-DDEFAULT_NOT_ONTOP',
     '-DXTERNAL_UI',
     '-DHAVE_IDLE_IFACE',

--- a/meson.build
+++ b/meson.build
@@ -18,18 +18,6 @@ deps = [
 name = 'Scarlett ' + get_option('num_inputs') + 'i' + get_option('num_outputs')
 apptitle = '-DAPPTITLE="' + name + ' Mixer"'
 
-conf = configuration_data()
-conf.set('SMI', get_option('num_inputs'))
-conf.set('SMO', get_option('num_outputs'))
-conf.set('SIN', get_option('num_inputs'))
-conf.set('SOUT', get_option('num_outputs'))
-conf.set_quoted('DEVICE_NAME', name + ' USB')
-
-configure_file(
-  output: 'config.h',
-  configuration: conf
-)
-
 executable('scarlett-mixer',
   sources: [
     'robtk/robtkapp.c',
@@ -41,7 +29,6 @@ executable('scarlett-mixer',
   c_args: [
     apptitle,
     '-xc++',  # temporary fix to make it compile with g++
-    '-DHAVE_CONFIG_H',
     '-DDEFAULT_NOT_ONTOP',
     '-DXTERNAL_UI',
     '-DHAVE_IDLE_IFACE',

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,7 @@ executable('scarlett-mixer',
   include_directories: include_directories('robtk'),
   c_args: [
     apptitle,
+    '-xc++',  # temporary fix to make it compile with g++
     '-DHAVE_CONFIG_H',
     '-DDEFAULT_NOT_ONTOP',
     '-DXTERNAL_UI',

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,51 @@
+project('scarlett-mixer', 'c')
+
+cc = meson.get_compiler('c')
+
+deps = [
+  dependency('cairo'),
+  dependency('pango'),
+  dependency('pangocairo'),
+  dependency('gl'),
+  dependency('glu'),
+  dependency('alsa'),
+  dependency('lv2'),
+  dependency('threads'),
+  cc.find_library('m'),
+  cc.find_library('X11'),
+]
+
+name = 'Scarlett ' + get_option('num_inputs') + 'i' + get_option('num_outputs')
+apptitle = '-DAPPTITLE="' + name + ' Mixer"'
+
+conf = configuration_data()
+conf.set('SMI', get_option('num_inputs'))
+conf.set('SMO', get_option('num_outputs'))
+conf.set('SIN', get_option('num_inputs'))
+conf.set('SOUT', get_option('num_outputs'))
+conf.set_quoted('DEVICE_NAME', name + ' USB')
+
+configure_file(
+  output: 'config.h',
+  configuration: conf
+)
+
+executable('scarlett-mixer',
+  sources: [
+    'robtk/robtkapp.c',
+    'robtk/ui_gl.c',
+    'robtk/pugl/pugl_x11.c',
+  ],
+  dependencies: deps,
+  include_directories: include_directories('robtk'),
+  c_args: [
+    apptitle,
+    '-DHAVE_CONFIG_H',
+    '-DDEFAULT_NOT_ONTOP',
+    '-DXTERNAL_UI',
+    '-DHAVE_IDLE_IFACE',
+    '-DRTK_DESCRIPTOR=lv2ui_descriptor',
+    '-DPLUGIN_SOURCE="src/scarlett_mixer.c"',
+    '-Wno-unused-function',
+  ],
+)

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,6 @@ executable('scarlett-mixer',
   include_directories: include_directories('robtk'),
   c_args: [
     apptitle,
-    '-xc++',  # temporary fix to make it compile with g++
     '-DDEFAULT_NOT_ONTOP',
     '-DXTERNAL_UI',
     '-DHAVE_IDLE_IFACE',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('num_inputs', type: 'string', value: '18', description: 'Number of inputs')
+option('num_outputs', type: 'string', value: '6', description: 'Number of outputs')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,0 @@
-option('num_inputs', type: 'string', value: '18', description: 'Number of inputs')
-option('num_outputs', type: 'string', value: '6', description: 'Number of outputs')

--- a/src/scarlett_mixer.c
+++ b/src/scarlett_mixer.c
@@ -36,6 +36,11 @@
  * https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/sound/usb/mixer_scarlett.c#n635
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#define DEVICE_NAME "Scarlett 18i6 USB"
+
 /* scarlett matrix size */
 #define SMI 18 // matrix ins
 #define SMO 6  // matrix outs
@@ -43,9 +48,9 @@
 /* scarlett I/O config */
 #define SIN 18 // inputs (capture select)
 #define SOUT 6 // outputs assigns (=?= matrix outs)
-#define SMST 3 // output gain (stereo gain controls w/mute  =?= SOUT / 2)
+#endif
 
-#define DEVICE_NAME "Scarlett 18i6 USB"
+#define SMST 3 // output gain (stereo gain controls w/mute  =?= SOUT / 2)
 
 
 typedef struct {

--- a/src/scarlett_mixer.c
+++ b/src/scarlett_mixer.c
@@ -36,21 +36,17 @@
  * https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/sound/usb/mixer_scarlett.c#n635
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#else
-#define DEVICE_NAME "Scarlett 18i6 USB"
+#define DEVICE_NAME "Scarlett 18i8 USB"
 
 /* scarlett matrix size */
 #define SMI 18 // matrix ins
-#define SMO 6  // matrix outs
+#define SMO 8  // matrix outs
 
 /* scarlett I/O config */
 #define SIN 18 // inputs (capture select)
-#define SOUT 6 // outputs assigns (=?= matrix outs)
-#endif
+#define SOUT 8 // outputs assigns (=?= matrix outs)
 
-#define SMST 3 // output gain (stereo gain controls w/mute  =?= SOUT / 2)
+#define SMST 4  // output gain (stereo gain controls w/mute  =?= SOUT / 2) */
 
 
 typedef struct {
@@ -114,7 +110,7 @@ static Mctrl* matrix_ctrl_cr (RobTkApp* ui, unsigned int c, unsigned int r)
 	if (r >= SMI || c >= SMO) {
 		return NULL;
 	}
-	unsigned int ctrl_id = 33 + r * 7 + c;
+	unsigned int ctrl_id = 38 + r * 9 + c;
 	return &ui->ctrl[ctrl_id];
 }
 
@@ -136,7 +132,7 @@ static Mctrl* matrix_sel (RobTkApp* ui, unsigned int r)
 	 *  ..
 	 * Matrix 18 Input, ENUM
 	 */
-	unsigned int ctrl_id = 32 + r * 7;
+	unsigned int ctrl_id = 37 + r * 9;
 	return &ui->ctrl[ctrl_id];
 }
 
@@ -150,7 +146,7 @@ static Mctrl* src_sel (RobTkApp* ui, unsigned int r)
 	 *  ..
 	 * Input Source 18, ENUM
 	 */
-	unsigned int ctrl_id = 13 + r;
+	unsigned int ctrl_id = 19 + r;
 	return &ui->ctrl[ctrl_id];
 }
 
@@ -163,11 +159,13 @@ static int src_sel_default (unsigned int r, int max_values)
 /* Output Gains */
 static Mctrl* out_gain (RobTkApp* ui, unsigned int c)
 {
-	switch (c) {
-		case 0: return &ui->ctrl[1]; /* Master 1 (Monitor), PBS */
-		case 1: return &ui->ctrl[4]; /* Master 2 (Headphone), PBS */
-		case 2: return &ui->ctrl[7]; /* Master 3 (SPDIF), PBS */
-	}
+    switch (c) {
+        case 0: return &ui->ctrl[1];  /* Master 1 (Monitor), PBS */
+        case 1: return &ui->ctrl[4];  /* Master 2 (Headphone), PBS */
+        case 2: return &ui->ctrl[7];  /* Master 3 (Headphone), PBS */
+        case 3: return &ui->ctrl[10]; /* Master 4 (Headphone), PBS */
+    }
+
 	return NULL;
 }
 
@@ -177,8 +175,10 @@ static const char* out_gain_label (int n)
 		case 0:
 			return "Monitor";
 		case 1:
-			return "Phones";
+			return "Phones 1";
 		case 2:
+			return "Phones 2";
+		case 3:
 			return "ADAT";
 		default:
 			return "??";
@@ -188,14 +188,16 @@ static const char* out_gain_label (int n)
 /* Output Bus assignment (matrix-out to master) */
 static Mctrl* out_sel (RobTkApp* ui, unsigned int c)
 {
-	switch (c) {
-		case 0: return &ui->ctrl[2]; /* Master 1L (Monitor) Source, ENUM */
-		case 1: return &ui->ctrl[3]; /* Master 1R (Monitor) Source, ENUM */
-		case 2: return &ui->ctrl[5]; /* Master 2L (Headphone) Source, ENUM */
-		case 3: return &ui->ctrl[6]; /* Master 2R (Headphone) Source, ENUM */
-		case 4: return &ui->ctrl[8]; /* Master 3L (SPDIF) Source, ENUM */
-		case 5: return &ui->ctrl[9]; /* Master 3R (SPDIF) Source, ENUM */
-	}
+    switch (c) {
+        case 0: return &ui->ctrl[2]; /* Master 1L (Monitor) Source, ENUM */
+        case 1: return &ui->ctrl[3]; /* Master 1R (Monitor) Source, ENUM */
+        case 2: return &ui->ctrl[5]; /* Master 2L (Headphone) Source, ENUM */
+        case 3: return &ui->ctrl[6]; /* Master 2R (Headphone) Source, ENUM */
+        case 4: return &ui->ctrl[8]; /* Master 3L (Headphone) Source, ENUM */
+        case 5: return &ui->ctrl[9]; /* Master 3R (Headphone) Source, ENUM */
+        case 6: return &ui->ctrl[11]; /* Master 4L (SPDIF) Source, ENUM */
+        case 7: return &ui->ctrl[12]; /* Master 4R (SPDIF) Source, ENUM */
+    }
 	return NULL;
 }
 
@@ -208,10 +210,10 @@ static int out_sel_default (unsigned int c)
 /* Hi-Z switches */
 static Mctrl* hiz (RobTkApp* ui, unsigned int c)
 {
-	switch (c) {
-		case 0: return &ui->ctrl[11]; /* Input 1 Impedance, ENUM */
-		case 1: return &ui->ctrl[12]; /* Input 2 Impedance, ENUM */
-	}
+    switch (c) {
+        case 0: return &ui->ctrl[13]; /* Input 1 Impedance, ENUM */
+        case 1: return &ui->ctrl[15]; /* Input 2 Impedance, ENUM */
+    }
 	return NULL;
 }
 


### PR DESCRIPTION
This PR adds mappings for the Focusrite Scarlett 18i8 and buttons to control the pads on the four front inputs. I wanted to keep compatibility with the 18i6 which required a bit of internal restructuring. The hardware mapping is now described by a struct which is now chosen dynamically at run-time. I also updated the dependency to robtk because a few things are akward to use in a mixed C/C++ environment (C filename extensions, string initializers in structs …).

Unfortunately, I do not own an 18i6, so I could not test if I broke something with that interface. But it should still work …