### PR TITLE
Fix SPDIF output labels

### DIFF
--- a/src/scarlett_mixer.c
+++ b/src/scarlett_mixer.c
@@ -79,7 +79,7 @@ static Device devices[] = {
 		.matrix_in_offset = 32, .matrix_in_stride = 7,
 		.input_offset = 13,
 		.out_gain_map = { 1 /* Monitor */, 4 /* Headphone */, 7 /* SPDIF */, -1, -1 , -1, -1, -1, -1, -1 },
-		.out_gain_labels = { "Monitor", "Headphone", "ADAT", "", "", "", "", "", "", "" },
+		.out_gain_labels = { "Monitor", "Headphone", "SPDIF", "", "", "", "", "", "", "" },
 		.out_bus_map = { 2, 3, 5, 6, 8, 9, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
 		.hiz_map = { 11, 12 },
 		.pad_map = { -1, -1, -1, -1 },
@@ -95,7 +95,7 @@ static Device devices[] = {
 		.matrix_in_offset = 37, .matrix_in_stride = 9,
 		.input_offset = 19,
 		.out_gain_map = { 1 /* Monitor */, 4 /* Headphone 1 */, 7 /* Headphone 2 */, 10 /* SPDIF */, -1, -1 , -1, -1, -1, -1 },
-		.out_gain_labels = { "Monitor", "Headphone 1", "Headphone 2", "ADAT", "", "", "", "", "", "" },
+		.out_gain_labels = { "Monitor", "Headphone 1", "Headphone 2", "SPDIF", "", "", "", "", "", "" },
 		.out_bus_map = { 2, 3, 5, 6, 8, 9, 11, 12, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
 		.hiz_map = { 13, 15 },
 		.pad_map = { 14, 16, 17, 18 },
@@ -110,7 +110,7 @@ static Device devices[] = {
 		.matrix_mix_offset = 33, .matrix_mix_stride = 9, // XXX stride should be 7, bug in kernel-driver ?!
 		.matrix_in_offset = 22, .matrix_in_stride = 9,   // XXX stride should be 7, bug in kernel-driver ?!
 		.out_gain_map = { 1 /* Monitor */, 4 /* Headphone */, 7 /* SPDIF */, -1, -1, -1 , -1, -1, -1, -1 },
-		.out_gain_labels = { "Monitor", "Headphone", "ADAT", "", "", "", "", "", "", "" },
+		.out_gain_labels = { "Monitor", "Headphone", "SPDIF", "", "", "", "", "", "", "" },
 		.out_bus_map = { 2, 3, 5, 6, 8, 9, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
 		.input_offset = 16,
 		.hiz_map = { 10, 12 },


### PR DESCRIPTION
Neither of the 6i6, 18i6 and 18i8 devices allows output via ADAT.